### PR TITLE
Add image detection summary

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -243,6 +243,7 @@ async def detect_image(
         # Process results
         emergency_detected = len(detections) > 0
         max_confidence = max((d['confidence'] for d in detections), default=0.0)
+        detected_vehicles = [d['class_name'] for d in detections]
 
         # Schedule cleanup
         background_tasks.add_task(cleanup_file, filepath)
@@ -256,7 +257,8 @@ async def detect_image(
                 "confidence": max_confidence,
                 "emergencyType": "MEDICAL" if emergency_detected else None,
                 "timestamp": datetime.now().isoformat(),
-                "processedImage": processed_image  # Add processed image to response
+                "processedImage": processed_image,  # Add processed image to response
+                "detectedVehicles": detected_vehicles  # Add detected vehicles to response
             }
         )
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -52,7 +52,11 @@ export const detectEmergencyInImage = async (file: File): Promise<DetectionRespo
   const result = await response.json();
   return {
     ...result,
-    originalImage: originalImageUrl
+    originalImage: originalImageUrl,
+    status: result.emergencyDetected ? "Emergency" : "Clear",
+    type: result.emergencyType,
+    confidence: result.confidence,
+    detectedVehicles: result.detections.map(det => det.class_name).join(', ')
   };
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,6 +22,9 @@ export interface DetectionResponse {
   message?: string;
   originalImage?: string;  // Base64 or URL of original uploaded media
   processedImage?: string; // Base64 or URL of processed media with YOLO detections
+  status: string;          // Status of the detection (e.g., "Emergency" or "Clear")
+  type: EmergencyType | null; // Type of emergency detected
+  detectedVehicles: string; // List of detected vehicles
 }
 
 export interface StationLocation {


### PR DESCRIPTION
Implement image generation detection summary with specified format.

* **backend/app.py**
  - Add `detectedVehicles` to the response in the `detect_image` endpoint.
  - Include detected vehicles in the response by extracting class names from detections.

* **lib/api.ts**
  - Format the detection summary to include status, type, confidence, and detected vehicles.
  - Add `status`, `type`, `confidence`, and `detectedVehicles` fields to the result.

* **lib/types.ts**
  - Update `DetectionResponse` type to include fields for status, type, confidence, and detected vehicles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/emergency/pull/5?shareId=da923e24-d025-408a-933b-3cbe9864882b).