### PR TITLE
Update nearest station selection to random

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -175,7 +175,7 @@ const UserDashboard: React.FC = () => {
     };
     const relevantStations = stationsByType[vehicleType as StationType] || [];
     if (relevantStations.length === 0) return null;
-    return relevantStations[0];
+    return relevantStations[Math.floor(Math.random() * relevantStations.length)];
   };
 
   const ModelStatusBadge = () => {

--- a/backend/utils/location.py
+++ b/backend/utils/location.py
@@ -60,9 +60,11 @@ def get_nearest_stations(location: List[float], emergency_type: str, stations: D
             'distance': distance
         })
 
-    # Sort by distance and return the nearest stations
+    # Sort by distance and return a random station
     sorted_stations = sorted(stations_with_distances, key=lambda x: x['distance'])
-    return sorted_stations[:3]  # Return top 3 nearest stations
+    if sorted_stations:
+        return [sorted_stations[np.random.randint(len(sorted_stations))]]
+    return []
 
 def bbox_to_location(bbox: List[int], image_size: Tuple[int, int], 
                     reference_coords: Optional[List[float]] = None) -> Dict[str, float]:


### PR DESCRIPTION
Update the `getNearestStation` function to return a random station for ambulance and police.

* **app/dashboard/page.tsx**
  - Modify `getNearestStation` function to return a random station from the list of relevant stations for ambulance and police.
  
* **backend/utils/location.py**
  - Update `get_nearest_stations` function to calculate distances to all relevant stations and sort them, but return a random station instead of the nearest one.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/emergency/pull/13?shareId=d200be59-12e6-4a48-8772-8edb7f8395d7).