### PR TITLE
Fix video detection not updating in API and development build

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -51,6 +51,7 @@ export const detectEmergencyInVideo = async (file: File): Promise<DetectionRespo
     timestamp: new Date().toISOString(),
     status: emergencyDetected ? 'Emergency' : 'Clear',
     originalImage: URL.createObjectURL(file),
+    processedImage: result.processedImage || undefined,
     detectedVehicles: detections.map((det: Detection) => det.class_name).join(', ')
   };
 };


### PR DESCRIPTION
Update the `detectEmergencyInVideo` function in `lib/api.ts` to handle the processed image in the response.

* Add `processedImage` to the detection results object.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/emergency/pull/15?shareId=b60e0a9a-790d-4e8e-87a8-a57c89117b44).