### PR TITLE
Fix Vercel configuration by removing functions property

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -29,12 +29,6 @@
             "dest": "/"
         }
     ],
-    "functions": {
-        ".vercel/backend/**/*.py": {
-            "memory": 3008,
-            "maxDuration": 30
-        }
-    },
     "env": {
         "PYTHONPATH": "/var/task/backend"
     }


### PR DESCRIPTION
Remove the `functions` property from the `vercel.json` file to avoid conflicts with the `builds` property.

* Remove the `functions` property which included configuration for serverless functions.
* Ensure the `builds` property remains intact and correctly configured.
* Maintain the `env` property for environment variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/emergency/pull/20?shareId=83636f2d-e388-4a92-84ce-9160565f995d).